### PR TITLE
Allow all remote origins

### DIFF
--- a/src/Browser/BrowserProcess.php
+++ b/src/Browser/BrowserProcess.php
@@ -291,6 +291,9 @@ class BrowserProcess implements LoggerAwareInterface
         $args = [
             $binary,
 
+            // allow remote access
+            '--remote-allow-origins=*',
+
             // auto debug port
             '--remote-debugging-port=0',
 


### PR DESCRIPTION
Backports https://github.com/chrome-php/chrome/pull/497 to 1.7 branch

Fixes an issue where Chrome >= 111 requires you to specify allowed remote origins